### PR TITLE
[L0][Core] 알고리즘 엔진 인터페이스 뼈대 (#3)

### DIFF
--- a/alg-sdlc-gan/src/features/graph/__tests__/engine.test.ts
+++ b/alg-sdlc-gan/src/features/graph/__tests__/engine.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { computeGraphSteps } from '../engine'
+
+describe('computeGraphSteps', () => {
+  it('더미 구현은 빈 배열을 반환한다', () => {
+    const graph = { nodes: [{ id: 'A', x: 0, y: 0 }], edges: [] }
+    expect(computeGraphSteps(graph, 'A', 'bfs')).toEqual([])
+    expect(computeGraphSteps(graph, 'A', 'dfs')).toEqual([])
+  })
+})

--- a/alg-sdlc-gan/src/features/graph/engine.ts
+++ b/alg-sdlc-gan/src/features/graph/engine.ts
@@ -1,0 +1,16 @@
+import type { GraphNode, GraphEdge, GraphStep } from '../../types'
+
+export type GraphAlgorithm = 'bfs' | 'dfs'
+
+export interface GraphInput {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+export function computeGraphSteps(
+  _graph: GraphInput,
+  _startNode: string,
+  _algorithm: GraphAlgorithm
+): GraphStep[] {
+  return []
+}

--- a/alg-sdlc-gan/src/features/sort/__tests__/engine.test.ts
+++ b/alg-sdlc-gan/src/features/sort/__tests__/engine.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { computeSortSteps } from '../engine'
+
+describe('computeSortSteps', () => {
+  it('더미 구현은 빈 배열을 반환한다', () => {
+    expect(computeSortSteps([3, 1, 2], 'bubble')).toEqual([])
+    expect(computeSortSteps([5], 'selection')).toEqual([])
+    expect(computeSortSteps([], 'insertion')).toEqual([])
+  })
+})

--- a/alg-sdlc-gan/src/features/sort/engine.ts
+++ b/alg-sdlc-gan/src/features/sort/engine.ts
@@ -1,0 +1,10 @@
+import type { SortStep } from '../../types'
+
+export type SortAlgorithm = 'bubble' | 'selection' | 'insertion'
+
+export function computeSortSteps(
+  array: number[],
+  _algorithm: SortAlgorithm
+): SortStep[] {
+  return []
+}


### PR DESCRIPTION
## Summary
computeSortSteps, computeGraphSteps 함수 시그니처 및 더미 구현 추가

## Changes
- src/features/sort/engine.ts: computeSortSteps 뼈대
- src/features/graph/engine.ts: computeGraphSteps 뼈대
- 단위 테스트 2개 통과

Closes #3