### PR TITLE
[L0][Frontend] App 기본 레이아웃 껍데기 (#4)

### DIFF
--- a/alg-sdlc-gan/eslint.config.js
+++ b/alg-sdlc-gan/eslint.config.js
@@ -19,5 +19,11 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
   },
 ])

--- a/alg-sdlc-gan/src/App.tsx
+++ b/alg-sdlc-gan/src/App.tsx
@@ -1,7 +1,27 @@
 function App() {
   return (
-    <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center">
-      <h1 className="text-3xl font-bold">Algorithm Visualization Playground</h1>
+    <div className="min-h-screen bg-slate-900 text-white">
+      <div className="mx-auto max-w-6xl p-4">
+        {/* AlgorithmSelector 영역 */}
+        <div
+          id="algorithm-selector"
+          className="mb-4 rounded-lg border border-slate-700 bg-slate-800 p-4"
+        />
+
+        <div className="flex flex-col gap-4 md:flex-row">
+          {/* VisualizationCanvas 영역 */}
+          <div
+            id="visualization-canvas"
+            className="flex-1 rounded-lg border border-slate-700 bg-slate-800 p-4"
+          />
+
+          {/* StepControls 영역 */}
+          <div
+            id="step-controls"
+            className="rounded-lg border border-slate-700 bg-slate-800 p-4 md:w-64"
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/alg-sdlc-gan/src/features/sort/engine.ts
+++ b/alg-sdlc-gan/src/features/sort/engine.ts
@@ -3,7 +3,7 @@ import type { SortStep } from '../../types'
 export type SortAlgorithm = 'bubble' | 'selection' | 'insertion'
 
 export function computeSortSteps(
-  array: number[],
+  _array: number[],
   _algorithm: SortAlgorithm
 ): SortStep[] {
   return []


### PR DESCRIPTION
## Summary
3-영역(AlgorithmSelector/Canvas/StepControls) Tailwind 레이아웃 구현

## Changes
- App.tsx: 3-영역 레이아웃, slate-900 배경, md 브레이크포인트 2-column
- eslint.config.js: _prefix 파라미터 허용 규칙 추가

Closes #4