### PR TITLE
[L0][Frontend] VisualizationCanvas + Canvas ref + drawFrame (#5)

### DIFF
--- a/alg-sdlc-gan/src/App.tsx
+++ b/alg-sdlc-gan/src/App.tsx
@@ -1,3 +1,5 @@
+import { VisualizationCanvas } from './components/VisualizationCanvas'
+
 function App() {
   return (
     <div className="min-h-screen bg-slate-900 text-white">
@@ -13,7 +15,9 @@ function App() {
           <div
             id="visualization-canvas"
             className="flex-1 rounded-lg border border-slate-700 bg-slate-800 p-4"
-          />
+          >
+            <VisualizationCanvas />
+          </div>
 
           {/* StepControls 영역 */}
           <div

--- a/alg-sdlc-gan/src/components/VisualizationCanvas.tsx
+++ b/alg-sdlc-gan/src/components/VisualizationCanvas.tsx
@@ -1,0 +1,38 @@
+import { useRef, useEffect } from 'react'
+
+function drawFrame(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  ctx.fillStyle = '#0f172a'
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = '#94a3b8'
+  ctx.font = '16px monospace'
+  ctx.textAlign = 'center'
+  ctx.fillText('캔버스 준비 완료', width / 2, height / 2)
+}
+
+interface Props {
+  width?: number
+  height?: number
+}
+
+export function VisualizationCanvas({ width = 600, height = 400 }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    drawFrame(ctx, width, height)
+  }, [width, height])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      role="img"
+      aria-label="알고리즘 시각화 캔버스"
+      className="rounded-lg"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
useRef로 Canvas DOM에 접근하고 더미 drawFrame을 구현합니다.

## Changes
- src/components/VisualizationCanvas.tsx: canvas role/aria-label 포함, drawFrame 더미 구현
- App.tsx: VisualizationCanvas 컴포넌트 통합

Closes #5