### PR TITLE
[L1][UI] 공통 UI 컴포넌트 AlgorithmSelector/StepControls/StepIndicator (#11)

### DIFF
--- a/alg-sdlc-gan/src/components/AlgorithmSelector.tsx
+++ b/alg-sdlc-gan/src/components/AlgorithmSelector.tsx
@@ -1,0 +1,59 @@
+import type { Algorithm } from '../types'
+
+type SortAlgo = 'bubble' | 'selection' | 'insertion'
+type GraphAlgo = 'bfs' | 'dfs'
+
+const SORT_TABS: { id: SortAlgo; label: string }[] = [
+  { id: 'bubble', label: '버블 정렬' },
+  { id: 'selection', label: '선택 정렬' },
+  { id: 'insertion', label: '삽입 정렬' },
+]
+
+const GRAPH_TABS: { id: GraphAlgo; label: string }[] = [
+  { id: 'bfs', label: 'BFS' },
+  { id: 'dfs', label: 'DFS' },
+]
+
+interface Props {
+  current: Algorithm
+  onSelect: (algo: Algorithm) => void
+}
+
+export function AlgorithmSelector({ current, onSelect }: Props) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <span className="text-sm text-slate-400 self-center mr-2">정렬:</span>
+      {SORT_TABS.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onSelect(tab.id)}
+          aria-label={`${tab.label} 선택`}
+          aria-pressed={current === tab.id}
+          className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+            current === tab.id
+              ? 'bg-indigo-600 text-white'
+              : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+      <span className="text-sm text-slate-400 self-center ml-4 mr-2">그래프:</span>
+      {GRAPH_TABS.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onSelect(tab.id)}
+          aria-label={`${tab.label} 선택`}
+          aria-pressed={current === tab.id}
+          className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+            current === tab.id
+              ? 'bg-indigo-600 text-white'
+              : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/alg-sdlc-gan/src/components/StepControls.tsx
+++ b/alg-sdlc-gan/src/components/StepControls.tsx
@@ -1,0 +1,82 @@
+import type { PlayState } from '../types'
+
+interface Props {
+  playState: PlayState
+  onPrev: () => void
+  onNext: () => void
+  onPlay: () => void
+  onPause: () => void
+  speed: number
+  onSpeedChange: (v: number) => void
+}
+
+export function StepControls({
+  playState,
+  onPrev,
+  onNext,
+  onPlay,
+  onPause,
+  speed,
+  onSpeedChange,
+}: Props) {
+  const isIdle = playState === 'idle'
+  const isPlaying = playState === 'playing'
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onPrev}
+          disabled={isIdle}
+          aria-label="이전 스텝"
+          className="rounded-md bg-slate-700 px-3 py-1.5 text-sm disabled:opacity-40"
+        >
+          ◀
+        </button>
+
+        {isPlaying ? (
+          <button
+            onClick={onPause}
+            disabled={isIdle}
+            aria-label="일시정지"
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm disabled:opacity-40"
+          >
+            ⏸
+          </button>
+        ) : (
+          <button
+            onClick={onPlay}
+            disabled={isIdle}
+            aria-label="재생"
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm disabled:opacity-40"
+          >
+            ▶
+          </button>
+        )}
+
+        <button
+          onClick={onNext}
+          disabled={isIdle}
+          aria-label="다음 스텝"
+          className="rounded-md bg-slate-700 px-3 py-1.5 text-sm disabled:opacity-40"
+        >
+          ▶▶
+        </button>
+      </div>
+
+      <label className="flex flex-col gap-1 text-sm text-slate-300">
+        속도
+        <input
+          type="range"
+          min={1}
+          max={5}
+          value={speed}
+          disabled={isIdle || isPlaying}
+          onChange={(e) => onSpeedChange(Number(e.target.value))}
+          aria-label="재생 속도"
+          className="accent-indigo-500 disabled:opacity-40"
+        />
+      </label>
+    </div>
+  )
+}

--- a/alg-sdlc-gan/src/components/StepIndicator.tsx
+++ b/alg-sdlc-gan/src/components/StepIndicator.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  currentStep: number
+  total: number
+}
+
+export function StepIndicator({ currentStep, total }: Props) {
+  if (total === 0) return null
+  return (
+    <p className="text-sm text-slate-400" aria-live="polite">
+      스텝 {currentStep + 1} / {total}
+    </p>
+  )
+}

--- a/alg-sdlc-gan/src/components/__tests__/StepControls.test.tsx
+++ b/alg-sdlc-gan/src/components/__tests__/StepControls.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StepControls } from '../StepControls'
+
+const noop = () => {}
+
+describe('StepControls', () => {
+  it('playState가 idle이면 모든 버튼이 비활성화된다', () => {
+    render(
+      <StepControls
+        playState="idle"
+        onPrev={noop}
+        onNext={noop}
+        onPlay={noop}
+        onPause={noop}
+        speed={3}
+        onSpeedChange={noop}
+      />
+    )
+    const buttons = screen.getAllByRole('button')
+    buttons.forEach((btn) => expect(btn).toHaveProperty('disabled', true))
+  })
+
+  it('재생 중에는 재생 버튼 대신 일시정지 버튼이 표시된다', () => {
+    render(
+      <StepControls
+        playState="playing"
+        onPrev={noop}
+        onNext={noop}
+        onPlay={noop}
+        onPause={noop}
+        speed={3}
+        onSpeedChange={noop}
+      />
+    )
+    expect(screen.getByLabelText('일시정지')).toBeDefined()
+  })
+
+  it('이전 스텝 버튼 클릭 시 onPrev가 호출된다', () => {
+    const onPrev = vi.fn()
+    render(
+      <StepControls
+        playState="paused"
+        onPrev={onPrev}
+        onNext={noop}
+        onPlay={noop}
+        onPause={noop}
+        speed={3}
+        onSpeedChange={noop}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('이전 스텝'))
+    expect(onPrev).toHaveBeenCalledOnce()
+  })
+})

--- a/alg-sdlc-gan/src/components/__tests__/StepIndicator.test.tsx
+++ b/alg-sdlc-gan/src/components/__tests__/StepIndicator.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StepIndicator } from '../StepIndicator'
+
+describe('StepIndicator', () => {
+  it('currentStep=2, total=10이면 "스텝 3 / 10"을 표시한다', () => {
+    render(<StepIndicator currentStep={2} total={10} />)
+    expect(screen.getByText('스텝 3 / 10')).toBeDefined()
+  })
+
+  it('total=0이면 아무것도 렌더링하지 않는다', () => {
+    const { container } = render(<StepIndicator currentStep={0} total={0} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/alg-sdlc-gan/vitest.config.ts
+++ b/alg-sdlc-gan/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    exclude: ['**/node_modules/**', '**/e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary
AlgorithmSelector, StepControls, StepIndicator 컴포넌트 구현

## Changes
- AlgorithmSelector: 정렬/그래프 탭 전환, aria-label/aria-pressed
- StepControls: 이전/다음/재생/일시정지, idle시 비활성화
- StepIndicator: 스텝 N/M 표시
- 단위 테스트 5개 추가
- vitest.config.ts: e2e 디렉터리 제외

Closes #11