### PR TITLE
[L2][slice-bubble] 버블소트 단계별 배열 시각화 (#12)

### DIFF
--- a/alg-sdlc-gan/e2e/bubble-sort.spec.ts
+++ b/alg-sdlc-gan/e2e/bubble-sort.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('@slice:bubble 버블소트 E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+  })
+
+  test('버블 정렬 선택 후 시작하면 Canvas가 표시된다', async ({ page }) => {
+    await page.getByRole('button', { name: '시작' }).click()
+    await expect(page.locator('canvas[role="img"]')).toBeVisible()
+  })
+
+  test('다음 스텝 클릭 시 스텝 인디케이터가 변경된다', async ({ page }) => {
+    await page.getByRole('button', { name: '시작' }).click()
+    const before = await page.locator('[aria-live="polite"]').textContent()
+    await page.getByLabel('다음 스텝').click()
+    const after = await page.locator('[aria-live="polite"]').textContent()
+    expect(before).not.toBe(after)
+  })
+})

--- a/alg-sdlc-gan/src/App.tsx
+++ b/alg-sdlc-gan/src/App.tsx
@@ -1,29 +1,30 @@
-import { VisualizationCanvas } from './components/VisualizationCanvas'
+import { useState } from 'react'
+import { AlgorithmSelector } from './components/AlgorithmSelector'
+import { SortPanel } from './features/sort/SortPanel'
+import type { Algorithm } from './types'
 
 function App() {
+  const [algorithm, setAlgorithm] = useState<Algorithm>(null)
+
+  const isSortAlgo = algorithm === 'bubble' || algorithm === 'selection' || algorithm === 'insertion'
+
   return (
     <div className="min-h-screen bg-slate-900 text-white">
-      <div className="mx-auto max-w-6xl p-4">
+      <div className="mx-auto max-w-4xl p-4 flex flex-col gap-4">
         {/* AlgorithmSelector 영역 */}
-        <div
-          id="algorithm-selector"
-          className="mb-4 rounded-lg border border-slate-700 bg-slate-800 p-4"
-        />
+        <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
+          <AlgorithmSelector current={algorithm} onSelect={setAlgorithm} />
+        </div>
 
-        <div className="flex flex-col gap-4 md:flex-row">
-          {/* VisualizationCanvas 영역 */}
-          <div
-            id="visualization-canvas"
-            className="flex-1 rounded-lg border border-slate-700 bg-slate-800 p-4"
-          >
-            <VisualizationCanvas />
-          </div>
-
-          {/* StepControls 영역 */}
-          <div
-            id="step-controls"
-            className="rounded-lg border border-slate-700 bg-slate-800 p-4 md:w-64"
-          />
+        {/* 메인 콘텐츠 */}
+        <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
+          {isSortAlgo ? (
+            <SortPanel algorithm={algorithm} />
+          ) : (
+            <div className="flex items-center justify-center h-40 text-slate-500 text-sm">
+              위에서 알고리즘을 선택하세요
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/alg-sdlc-gan/src/features/sort/SortCanvas.tsx
+++ b/alg-sdlc-gan/src/features/sort/SortCanvas.tsx
@@ -1,0 +1,70 @@
+import { useRef, useEffect } from 'react'
+import type { SortStep } from '../../types'
+
+interface Props {
+  step: SortStep | null
+  width?: number
+  height?: number
+}
+
+export function SortCanvas({ step, width = 600, height = 360 }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    ctx.fillStyle = '#0f172a'
+    ctx.fillRect(0, 0, width, height)
+
+    if (!step || step.array.length === 0) {
+      ctx.fillStyle = '#94a3b8'
+      ctx.font = '14px monospace'
+      ctx.textAlign = 'center'
+      ctx.fillText('배열을 입력하고 시작 버튼을 누르세요', width / 2, height / 2)
+      return
+    }
+
+    const arr = step.array
+    const n = arr.length
+    const max = Math.max(...arr.map(Math.abs), 1)
+    const barW = Math.floor((width - 40) / n) - 2
+    const padX = 20
+
+    arr.forEach((val, i) => {
+      const barH = Math.max(4, Math.floor((Math.abs(val) / max) * (height - 60)))
+      const x = padX + i * (barW + 2)
+      const y = height - 30 - barH
+
+      if (step.sorted.includes(i)) {
+        ctx.fillStyle = '#22c55e'
+      } else if (step.swapped && (step.swapped[0] === i || step.swapped[1] === i)) {
+        ctx.fillStyle = '#ef4444'
+      } else if (step.comparing && (step.comparing[0] === i || step.comparing[1] === i)) {
+        ctx.fillStyle = '#f97316'
+      } else {
+        ctx.fillStyle = '#6366f1'
+      }
+
+      ctx.fillRect(x, y, barW, barH)
+
+      ctx.fillStyle = '#cbd5e1'
+      ctx.font = '10px monospace'
+      ctx.textAlign = 'center'
+      ctx.fillText(String(val), x + barW / 2, height - 12)
+    })
+  }, [step, width, height])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      role="img"
+      aria-label="정렬 시각화 캔버스"
+      className="rounded-lg"
+    />
+  )
+}

--- a/alg-sdlc-gan/src/features/sort/SortPanel.tsx
+++ b/alg-sdlc-gan/src/features/sort/SortPanel.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useRef } from 'react'
+import { SortCanvas } from './SortCanvas'
+import { StepControls } from '../../components/StepControls'
+import { StepIndicator } from '../../components/StepIndicator'
+import { computeSortSteps } from './engine'
+import { validateSortInput } from './utils'
+import type { SortAlgorithm } from './engine'
+
+interface Props {
+  algorithm: SortAlgorithm
+}
+
+export function SortPanel({ algorithm }: Props) {
+  const [input, setInput] = useState('5,3,8,1,9,2')
+  const [steps, setSteps] = useState<ReturnType<typeof computeSortSteps>>([])
+  const [currentStep, setCurrentStep] = useState(0)
+  const [playState, setPlayState] = useState<'idle' | 'playing' | 'paused' | 'done'>('idle')
+  const [speed, setSpeed] = useState(3)
+  const [error, setError] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const handleStart = () => {
+    const result = validateSortInput(input)
+    if (!result.valid) {
+      setError(result.error)
+      return
+    }
+    setError(null)
+    const s = computeSortSteps(result.array, algorithm)
+    setSteps(s)
+    setCurrentStep(0)
+    setPlayState('paused')
+  }
+
+  useEffect(() => {
+    if (playState !== 'playing') {
+      if (timerRef.current) clearInterval(timerRef.current)
+      return
+    }
+    const delay = Math.max(100, 600 - speed * 100)
+    timerRef.current = setInterval(() => {
+      setCurrentStep((prev) => {
+        const next = prev + 1
+        if (next >= steps.length - 1) {
+          setPlayState('done')
+          clearInterval(timerRef.current!)
+          return steps.length - 1
+        }
+        return next
+      })
+    }, delay)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [playState, speed, steps.length])
+
+  const isDone = playState === 'done'
+  const currentStepData = steps[currentStep] ?? null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          disabled={playState === 'playing'}
+          placeholder="예: 5,3,8,1"
+          className="flex-1 rounded-md bg-slate-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+          aria-label="정렬할 배열 입력"
+        />
+        <button
+          onClick={handleStart}
+          className="rounded-md bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+        >
+          시작
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      <SortCanvas step={currentStepData} />
+
+      <div className="flex items-center justify-between">
+        <StepControls
+          playState={playState}
+          onPrev={() => setCurrentStep((p) => Math.max(0, p - 1))}
+          onNext={() => {
+            setCurrentStep((p) => {
+              const next = Math.min(p + 1, steps.length - 1)
+              if (next === steps.length - 1) setPlayState('done')
+              return next
+            })
+          }}
+          onPlay={() => setPlayState('playing')}
+          onPause={() => setPlayState('paused')}
+          speed={speed}
+          onSpeedChange={setSpeed}
+        />
+        <StepIndicator currentStep={currentStep} total={steps.length} />
+      </div>
+
+      {isDone && (
+        <div className="flex items-center justify-between rounded-md bg-slate-700 px-4 py-2">
+          <span className="text-sm text-green-400 font-medium">정렬 완료!</span>
+          <button
+            onClick={() => {
+              setCurrentStep(0)
+              setPlayState('paused')
+            }}
+            className="rounded-md bg-slate-600 px-3 py-1 text-sm text-white hover:bg-slate-500"
+          >
+            처음으로
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/alg-sdlc-gan/src/features/sort/engine.ts
+++ b/alg-sdlc-gan/src/features/sort/engine.ts
@@ -1,10 +1,121 @@
 import type { SortStep } from '../../types'
+import { copyArray } from './utils'
 
 export type SortAlgorithm = 'bubble' | 'selection' | 'insertion'
 
 export function computeSortSteps(
   _array: number[],
-  _algorithm: SortAlgorithm
+  algorithm: SortAlgorithm
 ): SortStep[] {
-  return []
+  switch (algorithm) {
+    case 'bubble':
+      return computeBubbleSteps(_array)
+    case 'selection':
+      return computeSelectionSteps(_array)
+    case 'insertion':
+      return computeInsertionSteps(_array)
+  }
+}
+
+function computeBubbleSteps(input: number[]): SortStep[] {
+  const arr = copyArray(input)
+  const steps: SortStep[] = []
+  const sorted: number[] = []
+  const n = arr.length
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [] })
+
+  for (let i = 0; i < n - 1; i++) {
+    for (let j = 0; j < n - 1 - i; j++) {
+      steps.push({
+        array: copyArray(arr),
+        comparing: [j, j + 1],
+        swapped: null,
+        sorted: copyArray(sorted),
+      })
+
+      if (arr[j] > arr[j + 1]) {
+        ;[arr[j], arr[j + 1]] = [arr[j + 1], arr[j]]
+        steps.push({
+          array: copyArray(arr),
+          comparing: null,
+          swapped: [j, j + 1],
+          sorted: copyArray(sorted),
+        })
+      }
+    }
+    sorted.unshift(n - 1 - i)
+  }
+  sorted.unshift(0)
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [...Array(n).keys()] })
+  return steps
+}
+
+function computeSelectionSteps(input: number[]): SortStep[] {
+  const arr = copyArray(input)
+  const steps: SortStep[] = []
+  const sorted: number[] = []
+  const n = arr.length
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [] })
+
+  for (let i = 0; i < n - 1; i++) {
+    let minIdx = i
+    for (let j = i + 1; j < n; j++) {
+      steps.push({
+        array: copyArray(arr),
+        comparing: [minIdx, j],
+        swapped: null,
+        sorted: copyArray(sorted),
+      })
+      if (arr[j] < arr[minIdx]) minIdx = j
+    }
+    if (minIdx !== i) {
+      ;[arr[i], arr[minIdx]] = [arr[minIdx], arr[i]]
+      steps.push({
+        array: copyArray(arr),
+        comparing: null,
+        swapped: [i, minIdx],
+        sorted: copyArray(sorted),
+      })
+    }
+    sorted.push(i)
+  }
+  sorted.push(n - 1)
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [...Array(n).keys()] })
+  return steps
+}
+
+function computeInsertionSteps(input: number[]): SortStep[] {
+  const arr = copyArray(input)
+  const steps: SortStep[] = []
+  const n = arr.length
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [0] })
+
+  for (let i = 1; i < n; i++) {
+    let j = i
+    steps.push({
+      array: copyArray(arr),
+      comparing: [i, j - 1],
+      swapped: null,
+      sorted: [...Array(i).keys()],
+    })
+
+    while (j > 0 && arr[j - 1] > arr[j]) {
+      ;[arr[j - 1], arr[j]] = [arr[j], arr[j - 1]]
+      steps.push({
+        array: copyArray(arr),
+        comparing: null,
+        swapped: [j - 1, j],
+        sorted: [...Array(i).keys()],
+      })
+      j--
+    }
+  }
+
+  steps.push({ array: copyArray(arr), comparing: null, swapped: null, sorted: [...Array(n).keys()] })
+  return steps
 }


### PR DESCRIPTION
## Summary
버블소트 단계별 Canvas 렌더링, SortPanel, E2E 시나리오 구현

## Changes
- src/features/sort/engine.ts: 버블/선택/삽입 정렬 스텝 계산 구현
- src/features/sort/SortCanvas.tsx: 비교(주황)/스왑(빨강)/확정(초록) 색상 Canvas
- src/features/sort/SortPanel.tsx: 입력→시작→스텝 제어→완료 전체 플로우
- e2e/bubble-sort.spec.ts: @slice:bubble E2E 시나리오

Closes #12