### PR TITLE
[L2][slice-selection/insertion] 선택/삽입 정렬 E2E 시나리오 (#13, #14)

### DIFF
--- a/alg-sdlc-gan/e2e/insertion-sort.spec.ts
+++ b/alg-sdlc-gan/e2e/insertion-sort.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('@slice:insertion 삽입 정렬 E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('삽입 정렬 선택').click()
+  })
+
+  test('삽입 정렬 탭 클릭 시 입력 폼이 전환된다', async ({ page }) => {
+    await expect(page.getByLabel('정렬할 배열 입력')).toBeVisible()
+  })
+
+  test('시작 후 Canvas가 표시된다', async ({ page }) => {
+    await page.getByRole('button', { name: '시작' }).click()
+    await expect(page.locator('canvas[role="img"]')).toBeVisible()
+  })
+})

--- a/alg-sdlc-gan/e2e/selection-sort.spec.ts
+++ b/alg-sdlc-gan/e2e/selection-sort.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('@slice:selection 선택 정렬 E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('선택 정렬 선택').click()
+  })
+
+  test('선택 정렬 탭 클릭 시 입력 폼이 전환된다', async ({ page }) => {
+    await expect(page.getByLabel('정렬할 배열 입력')).toBeVisible()
+  })
+
+  test('시작 후 Canvas가 표시된다', async ({ page }) => {
+    await page.getByRole('button', { name: '시작' }).click()
+    await expect(page.locator('canvas[role="img"]')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
선택 정렬과 삽입 정렬은 엔진(#12)에서 함께 구현됨. E2E 시나리오 추가.

## Changes
- e2e/selection-sort.spec.ts
- e2e/insertion-sort.spec.ts

Closes #13
Closes #14