### PR TITLE
[L3][UI/UX] 반응형 2-column 레이아웃 + 키보드 탐색 + 접근성 (#18)

### DIFF
--- a/alg-sdlc-gan/docs/evaluations/issue-18/qa-report-iter-1.md
+++ b/alg-sdlc-gan/docs/evaluations/issue-18/qa-report-iter-1.md
@@ -1,0 +1,152 @@
+# QA Report — Issue #18 — Iteration 1
+
+- 평가 시각: 2026-04-19T12:22:00+09:00
+- 기준: `docs/evaluations/issue-18/sprint-contract.md`
+- 평가자 모델: opus
+- 브랜치: `feature/issue-18-responsive-a11y`
+
+## 1. TC 결과
+
+| ID | 본문 요약 | 결과 | 근거(출력 인용) |
+|----|-----------|------|-----------------|
+| TC-01 | 뷰포트 768px SortPanel 2-column + canvas.x > input.x | ✅ PASS | Playwright: `[chromium/firefox/webkit] › 뷰포트 768px에서 2-column 레이아웃 확인` — 실패 목록에 없음 (passed in 3 browsers). |
+| TC-02 | 뷰포트 768px GraphPanel 2-column + canvas.x > edgeInput.x | ✅ PASS | Playwright: `그래프 BFS 2-column 레이아웃 확인` — 실패 목록에 없음 (passed in 3 browsers). |
+| TC-03 | ArrowRight 후 aria-live 텍스트 변화 | ❌ FAIL | `[chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:24:3 › 방향키로 이전/다음 스텝 이동` — `<canvas role="img" width="600" ...> subtree intercepts pointer events`; `시작` 버튼 click 타임아웃 30000ms. |
+| TC-04 | ArrowLeft 후 aria-live 이전 값 복원 | ❌ FAIL | TC-03과 동일 테스트 블록에서 `시작` 클릭 자체가 실패 → ArrowLeft assertion까지 도달 못함. |
+| TC-05 | `npm test -- useKeyboardNav` (active=false 시 onNext 미호출) | ❌ FAIL | `npm test -- useKeyboardNav` → `No test files found, exiting with code 1`. `src/hooks/useKeyboardNav.spec.ts` 미존재 (`find` 결과 `useKeyboardNav.ts`만 존재). |
+| TC-06 | `aria-label="이전 스텝"/"다음 스텝"/"재생"` 버튼 DOM 존재 | ❌ FAIL | `[chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:41:3 › 모든 StepControls 버튼에 aria-label 존재` — `시작` 버튼 click 캔버스에 의한 pointer intercept로 타임아웃. (※ 소스에 aria-label은 존재하나 E2E 검증 불가) |
+| TC-07 | canvas에 `role="img"` 존재 | ✅ PASS | `Canvas에 role="img" 속성 존재` 실패 목록에 없음. SortCanvas.tsx:65 `role="img"`, GraphCanvas.tsx:89 `role="img"` 확인. |
+| TC-08 | 이전 스텝 버튼 height ≥ 44 | ❌ FAIL | `[chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:58:3 › StepControls 버튼 터치 타깃 44px 이상` — 동일 canvas intercept로 타임아웃. |
+| TC-09 | `npm run build` exit 0, 타입 에러 없음 | ✅ PASS | `npm run build` → `✓ built in 70ms` / `dist/index.html 0.45 kB` / `---EXIT:0`. |
+| TC-10 | `npm run test:e2e -- e2e/responsive-a11y.spec.ts` 6개 모두 pass | ❌ FAIL | Playwright 실행 결과 `9 failed / 9 passed (1.1m)` — 6개 테스트 × 3 브라우저 중 9개(50%)가 실패. TC-10의 "6개 모두 passed" 조건 미달. |
+
+- **TC Pass Rate**: 4/10 = **40%**
+
+---
+
+## 2. Rubric 점수
+
+| # | 항목 | 점수 | 근거 |
+|---|------|------|------|
+| 1 | TC Pass Rate | **4** | `floor(4/10 × 10) = 4`. 10개 중 4개 PASS(TC-01, TC-02, TC-07, TC-09). |
+| 2 | Build & Test Health | **6** | `npm run build` exit 0 / 0 warning (`✓ built in 70ms`), `npm test` exit 0 (8 files / 25 tests passed). 그러나 E2E `npx playwright test e2e/responsive-a11y.spec.ts` `9 failed / 9 passed` — 테스트 기준 신뢰도 저하. build OK + unit test OK + e2e 50% 실패 → 6. |
+| 3 | AC Coverage | **7** | AC 키워드 → 실제 diff 등장 확인: (a) `md:grid-cols-2` → `SortPanel.tsx:75`, `GraphPanel.tsx:107` 등장 ✓; (b) `ArrowLeft/ArrowRight` → `useKeyboardNav.ts:13,16` 등장 ✓; (c) `aria-label` → `StepControls.tsx:31,41,50,60` 등장 ✓; (d) `role="img"` → `SortCanvas.tsx:65`, `GraphCanvas.tsx:89` 등장 ✓; (e) `min-h-[44px]` → `StepControls.tsx:32,42,51,61` 등장 ✓. 코드 상 AC 4개 모두 다뤄짐. 다만 실 동작 검증(E2E)에서 3개 AC가 통과하지 못해 -3점. |
+| 4 | Code Hygiene | **8** | lint 실행 결과 확인 불가(`package.json`에 lint 스크립트 상태 미파악) → 감점 -1. 네이밍/위치 기존 규칙 준수: 훅 `src/hooks/useKeyboardNav.ts` (신규 디렉토리이나 React 관용), aria-label 한국어(기존 `AlgorithmSelector` 컨벤션 일치, 예: `버블 정렬 선택`), `min-h-[44px]` 일관 적용. 기존 컨벤션 위반 0. build 시 TS warning 0. |
+| 5 | Scope Discipline | **5** | Non-goals: `src/features/sort/engine.ts`, `src/features/graph/engine.ts` 수정 금지 → `git diff master --stat` 결과 두 파일 모두 미변경 ✓. 그러나 다음 파일들이 이슈 범위 밖에서 수정됨: `.claude/commands/implement.md`, `.claude/commands/ship.md`, `.claude/commands/ship-all.md`, `.claude/go-sdlc-gan.json`, `.claude/skills/auto-ship/SKILL.md`, `.claude/skills/github-flow-impl/SKILL.md`, `.claude/skills/github-kanban/SKILL.md` — **7개 파일 / 143 lines** 범위 외 변경(diff stat: `.claude/skills/github-kanban/SKILL.md | 58`, `auto-ship/SKILL.md | 56` 등). Scope 침범 7개 파일 → 강한 감점. |
+| 6 | Regression Safety | **9** | 기존 unit test 25개 모두 pass (`Tests 25 passed (25)`). 기존 E2E (bubble/insertion/selection/home/cross-algo)도 `9 passed`로 새 spec 외 파손 증거 없음. diff stat: 순수 추가 우세(`+271/-146`), 신규 파일 `e2e/responsive-a11y.spec.ts`, `src/hooks/useKeyboardNav.ts`. SortPanel/GraphPanel/StepControls는 기존 컴포넌트 수정이나 기존 테스트 전체 통과. |
+| 7 | User Value Trace | **4** | E2E 시나리오: "사용자가 768px 모바일 태블릿에서 버블 정렬을 시작한 후 방향키로 스텝을 이동한다" → TC-01 2-column 레이아웃은 통과하나, 방향키 이동 테스트(TC-03/04)와 터치 타깃(TC-08)이 실 브라우저에서 검증 불가. 특히 1280px 기본 뷰포트에서 `canvas[width=600]`가 grid 컬럼(≈432px)을 overflow하여 `시작` 버튼의 pointer event를 가로챔 — 실제 데스크톱 사용자가 "시작 버튼을 누르는" 핵심 행동이 불가능할 수 있음 (Playwright 로그: `<canvas role="img" width="600" height="360" ...> subtree intercepts pointer events`). E2E 1개 상상 실행 결과: **일부 경로 차단**. |
+
+- **평균**: (4 + 6 + 7 + 8 + 5 + 9 + 4) / 7 = **6.14**
+- **최저 항목**: #1 TC Pass Rate = **4**, #7 User Value Trace = **4**
+
+---
+
+## 3. 판정
+
+- 평균 6.14 ≥ 8.0 ? **NO**
+- 모든 항목 ≥ 6.0 ? **NO** (#1 = 4, #5 = 5, #7 = 4)
+- **판정: FAIL**
+
+---
+
+## 4. 정체(plateau) 감지
+
+- iter == 1 → **N/A** (이전 리포트 없음)
+
+---
+
+## 5. Generator Feedback
+
+> 다음 iteration의 Generator가 입력으로 받는다. 구체·행동가능.
+
+### 우선 수정 (영향도 순)
+
+1. **`src/features/sort/SortPanel.tsx:129` / `src/features/graph/GraphPanel.tsx:170` — Canvas의 고정 width 때문에 우측 컬럼이 overflow**
+   - 현재 상태: `<SortCanvas step={currentStepData} />` (Canvas 내부에서 `width=600` 기본값), 우측 컨테이너 `<div className="flex items-start justify-center">`
+   - 기대 상태: 부모 컨테이너에 `min-w-0` 또는 `overflow-hidden` 적용 + Canvas를 `className="max-w-full h-auto"` 로 반응형화 (또는 Canvas 컨테이너에 `w-full` + canvas에 `w-full`). 이유: Playwright 로그 `<canvas role="img" width="600" ...> subtree intercepts pointer events` — 1280px 뷰포트에서 `max-w-4xl`(896px) 안의 `md:grid-cols-2` 컬럼은 ≈432px로, 600px canvas가 좌측 컬럼의 `시작` 버튼 영역을 가림.
+   - 관련 TC: TC-03, TC-04, TC-06, TC-08, TC-10 / rubric 항목 #1, #2, #7
+   - 검증: `npx playwright test e2e/responsive-a11y.spec.ts --project=chromium`이 6/6 통과해야 함.
+
+2. **`src/hooks/useKeyboardNav.spec.ts` 파일 누락 — TC-05 unit test 부재**
+   - 현재 상태: `find src -name "*useKeyboardNav*"` → `useKeyboardNav.ts` 단 1개. `npm test -- useKeyboardNav` → `No test files found, exiting with code 1`.
+   - 기대 상태: `src/hooks/useKeyboardNav.spec.ts` 생성. Vitest + `@testing-library/react`의 `renderHook` 사용. 최소 3개 케이스: (a) `active=true`일 때 ArrowRight → onNext 호출 1회, (b) `active=false`일 때 ArrowRight → onNext 호출 0회, (c) Input에 focus된 상태에서 ArrowRight → onNext 호출 0회.
+   - 관련 TC: TC-05 / rubric 항목 #1
+
+3. **`.claude/` 하위 7개 파일 범위 외 수정 되돌리기**
+   - 현재 상태: `git diff --stat`에 `.claude/commands/implement.md`, `.claude/commands/ship.md`, `.claude/commands/ship-all.md`, `.claude/go-sdlc-gan.json`, `.claude/skills/auto-ship/SKILL.md`, `.claude/skills/github-flow-impl/SKILL.md`, `.claude/skills/github-kanban/SKILL.md` 7개가 수정됨(총 143 lines).
+   - 기대 상태: `git restore .claude/` 로 되돌리거나 **별도 이슈/PR**로 분리. 이슈 #18은 "반응형 레이아웃 + 접근성"이지 ship 자동화 메타 수정이 아님.
+   - 관련 TC: N/A / rubric 항목 #5
+
+### 건드리지 말 것
+
+- `src/features/sort/engine.ts` — sprint-contract Non-goals 명시 (이미 미변경 ✓)
+- `src/features/graph/engine.ts` — sprint-contract Non-goals 명시 (이미 미변경 ✓)
+- 정렬/그래프 로직, 알고리즘 시각화 배치 로직
+
+### plateau 사유 (해당 없음)
+
+- iter 1이라 plateau 판정 불가.
+
+---
+
+## 6. 메타
+
+### build log tail
+```
+> alg-sdlc-gan@0.0.0 build
+> tsc -b && vite build
+
+vite v8.0.8 building client environment for production...
+✓ 28 modules transformed.
+dist/index.html                   0.45 kB │ gzip:  0.29 kB
+dist/assets/index-IhX2iWM0.css   11.38 kB │ gzip:  3.18 kB
+dist/assets/index-BiumqrKQ.js   204.92 kB │ gzip: 64.25 kB
+
+✓ built in 70ms
+EXIT:0
+```
+
+### test log tail (unit)
+```
+> alg-sdlc-gan@0.0.0 test
+> vitest run
+
+ RUN  v4.1.4 /Users/insang/Documents/lab/practices/alg-sdlc-gan
+
+ Test Files  8 passed (8)
+      Tests  25 passed (25)
+   Start at  12:19:26
+   Duration  709ms
+EXIT:0
+```
+
+### Playwright log tail (responsive-a11y)
+```
+9 failed
+  [chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:24:3 › 방향키로 이전/다음 스텝 이동
+  [chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:41:3 › 모든 StepControls 버튼에 aria-label 존재
+  [chromium/firefox/webkit] › e2e/responsive-a11y.spec.ts:58:3 › StepControls 버튼 터치 타깃 44px 이상
+9 passed (1.1m)
+
+Representative failure stack:
+  locator.click: Test timeout of 30000ms exceeded.
+  - <canvas role="img" width="600" height="360" class="rounded-lg" aria-label="정렬 시각화 캔버스">
+    from <div class="flex items-start justify-center">…</div>
+    subtree intercepts pointer events
+```
+
+### changed files (`git diff --stat`)
+```
+ .claude/commands/implement.md         |   1 -
+ .claude/commands/ship-all.md          |   1 -
+ .claude/commands/ship.md              |   1 -
+ .claude/go-sdlc-gan.json              |   4 +-
+ .claude/skills/auto-ship/SKILL.md     |  56 +++++-
+ .claude/skills/github-flow-impl/SKILL.md |  24 +++-
+ .claude/skills/github-kanban/SKILL.md  |  58 +++++--
+ src/components/StepControls.tsx       |   8 +-
+ src/features/graph/GraphPanel.tsx     | 147 ++++++++++++---------
+ src/features/sort/SortPanel.tsx       | 117 +++++++++-------
+ (+ untracked) e2e/responsive-a11y.spec.ts, src/hooks/useKeyboardNav.ts
+ 10 files changed, 271 insertions(+), 146 deletions(-)
+```

--- a/alg-sdlc-gan/docs/evaluations/issue-18/qa-report-iter-2.md
+++ b/alg-sdlc-gan/docs/evaluations/issue-18/qa-report-iter-2.md
@@ -1,0 +1,170 @@
+# QA Report — Issue #18 — Iteration 2
+
+- 평가 시각: 2026-04-19T12:34:00+09:00
+- 기준: `docs/evaluations/issue-18/sprint-contract.md`
+- 평가자 모델: opus
+- 브랜치: `feature/issue-18-responsive-a11y`
+- 이전 리포트: `docs/evaluations/issue-18/qa-report-iter-1.md` (평균 6.14, FAIL)
+
+## 1. TC 결과
+
+| ID | 본문 요약 | 결과 | 근거(출력 인용) |
+|----|-----------|------|-----------------|
+| TC-01 | 뷰포트 768px SortPanel 2-column + canvas.x > input.x | ✅ PASS | Playwright: `✓ 2 [chromium] › e2e/responsive-a11y.spec.ts:4:3 › @slice:a11y ... › 뷰포트 768px에서 2-column 레이아웃 확인 (529ms)` — chromium/firefox/webkit 3개 모두 통과. |
+| TC-02 | 뷰포트 768px GraphPanel 2-column + canvas.x > edgeInput.x | ✅ PASS | Playwright: `✓ 6 [chromium] › ... › 그래프 BFS 2-column 레이아웃 확인 (254ms)`, `✓ 12 [firefox] (600ms)`, `✓ 17 [webkit] (382ms)`. |
+| TC-03 | ArrowRight 후 aria-live 텍스트 변화 | ✅ PASS | Playwright: `✓ 3 [chromium] › e2e/responsive-a11y.spec.ts:24:3 › ... › 방향키로 이전/다음 스텝 이동 (595ms)` — 3개 브라우저 모두 통과. 테스트 내부가 `expect(step2).not.toBe(step1)` 및 `expect(step3).toBe(step1)` 단언을 포함(spec line 34, 38) → ArrowLeft 복원까지 검증 완료. |
+| TC-04 | ArrowLeft 후 aria-live 이전 값 복원 | ✅ PASS | TC-03과 동일 테스트 블록 내 `expect(step3).toBe(step1)` (`e2e/responsive-a11y.spec.ts:38`) assertion 포함. 테스트 전체가 PASS했으므로 이 assertion도 성립. |
+| TC-05 | `npm test -- useKeyboardNav` (active=false 시 onNext 미호출 + 기타 케이스) | ✅ PASS | `npm test` → `Test Files 9 passed (9) / Tests 31 passed (31)` (iter-1은 8 files / 25 tests). 신규 파일 `src/hooks/__tests__/useKeyboardNav.spec.ts` 존재(82 lines, 6 `it` 블록) 및 케이스 `'active=false일 때 ArrowRight를 눌러도 onNext가 호출되지 않는다'` (spec line 36) 포함. |
+| TC-06 | `aria-label="이전 스텝"/"다음 스텝"/"재생"` 버튼 DOM 존재 | ✅ PASS | Playwright: `✓ 5 [chromium] › e2e/responsive-a11y.spec.ts:41:3 › ... › 모든 StepControls 버튼에 aria-label 존재 (572ms)`, `✓ 9 [firefox] (1.1s)`, `✓ 15 [webkit] (588ms)`. 소스 증거: `StepControls.tsx:31` `aria-label="이전 스텝"`, `:50` `aria-label="재생"`, `:60` `aria-label="다음 스텝"`. |
+| TC-07 | canvas에 `role="img"` 존재 | ✅ PASS | Playwright: `✓ 4 [chromium] › ... › Canvas에 role="img" 속성 존재 (515ms)`. 소스: `SortCanvas.tsx:66` `role="img"`, `GraphCanvas.tsx:90` `role="img"`. |
+| TC-08 | 이전 스텝 버튼 height ≥ 44 | ✅ PASS | Playwright: `✓ 1 [chromium] › ... › StepControls 버튼 터치 타깃 44px 이상 (610ms)`, `✓ 11 [firefox] (1.3s)`, `✓ 18 [webkit] (392ms)`. 소스: `StepControls.tsx:32` `min-h-[44px]`. |
+| TC-09 | `npm run build` exit 0, 타입 에러 없음 | ✅ PASS | `npm run build` → `✓ built in 61ms` / `dist/assets/index-CbrWzmUV.js 205.14 kB` / `---EXIT:0---`. stderr 타입 에러 없음. |
+| TC-10 | `npm run test:e2e -- e2e/responsive-a11y.spec.ts` 6개 모두 pass | ✅ PASS | `npx playwright test e2e/responsive-a11y.spec.ts` → `18 passed (7.4s)` / `---EXIT:0---`. 6 테스트 × 3 브라우저 = 18개 전부 통과. |
+
+- **TC Pass Rate**: 10/10 = **100%** (iter-1: 4/10 = 40% → +60%p)
+
+---
+
+## 2. Rubric 점수
+
+| # | 항목 | 점수 | 근거 |
+|---|------|------|------|
+| 1 | TC Pass Rate | **10** | `floor(10/10 × 10) = 10`. 10개 전부 PASS (iter-1: 4). |
+| 2 | Build & Test Health | **10** | `npm run build` exit 0 / 0 warning (`✓ built in 61ms`); `npm test` exit 0 (`Test Files 9 passed (9) / Tests 31 passed (31) Duration 798ms`); `npx playwright test e2e/responsive-a11y.spec.ts` `18 passed (7.4s)` EXIT 0; `npx playwright test` 전체 `48 passed (9.5s)` EXIT 0; `npm run lint` EXIT 0 (warning 0). (iter-1: 6) |
+| 3 | AC Coverage | **10** | AC 키워드 → diff 등장 전부 확인: (a) `md:grid-cols-2` → `SortPanel.tsx:75`, `GraphPanel.tsx:107`; (b) `ArrowLeft/ArrowRight` → `useKeyboardNav.ts:13,16`, 단위 테스트 `useKeyboardNav.spec.ts` 6 케이스; (c) `aria-label` → `StepControls.tsx:31,41,50,60` (이전/일시정지/재생/다음) + `:76` `속도 조절`; (d) `role="img"` → `SortCanvas.tsx:66`, `GraphCanvas.tsx:90`; (e) `min-h-[44px]` → `StepControls.tsx:32,42,51,61`, `SortPanel.tsx:91,119`, `GraphPanel.tsx:132,160`. 코드 + E2E 실측 전부 일치. (iter-1: 7) |
+| 4 | Code Hygiene | **10** | `npm run lint` EXIT 0, warning 0. 네이밍/위치 규칙 준수: 훅은 `src/hooks/` 아래, 신규 테스트는 `src/hooks/__tests__/` (Vitest 관용 컨벤션). aria-label 한국어 규칙 일치(`'이전 스텝'`, `'다음 스텝'`, `'재생'`, `'속도 조절'` — 이전 iter-1의 `'속도'`에서 `'속도 조절'`로 명시화됨 `StepControls.tsx:76`). TS build 0 warning. (iter-1: 8) |
+| 5 | Scope Discipline | **9** | Non-goals 엄수 확인: `git diff master..HEAD src/features/sort/engine.ts src/features/graph/engine.ts` 출력 비어있음(미변경 ✓). staged 변경 파일 8개 전부 이슈 범위 내: `e2e/responsive-a11y.spec.ts`(신규), `src/components/StepControls.tsx`, `src/features/sort/SortPanel.tsx`, `src/features/sort/SortCanvas.tsx`, `src/features/graph/GraphPanel.tsx`, `src/features/graph/GraphCanvas.tsx`, `src/hooks/useKeyboardNav.ts`(신규), `src/hooks/__tests__/useKeyboardNav.spec.ts`(신규). `.claude/` 하위 7개 파일은 여전히 workdir 수정 상태(unstaged)지만 **staged diff에서 제외**되어 다음 commit에는 포함되지 않는다. 단, 리포 상에 "대기 중인 오염 파일"이 남아있어 -1 감점(깔끔한 되돌림이 아님). (iter-1: 5) |
+| 6 | Regression Safety | **10** | 기존 unit test 파손 0: iter-1 25 tests → iter-2 31 tests 모두 passed (+6 신규). 기존 E2E 파손 0: `npx playwright test` 전체 `48 passed (9.5s)` EXIT 0 — bubble/insertion/selection/home/cross-algo/responsive-a11y 모든 슬라이스 통과. staged diff stat `+366/-138` — 순수 추가 비중 72%. `engine.ts` 2개 파일 무변경. (iter-1: 9) |
+| 7 | User Value Trace | **10** | E2E 시나리오: "사용자가 768px 태블릿에서 BFS를 선택하고, 그래프를 입력·시작한 뒤 방향키로 스텝을 전/후로 움직여 결과를 확인한다" → `e2e/responsive-a11y.spec.ts:24-39` (방향키) + `:68-84` (그래프 2-column) 전부 PASS. 특히 iter-1의 치명적 차단 증거였던 `<canvas role="img" width="600" ...> subtree intercepts pointer events` 이슈가 해소된 근거: `SortCanvas.tsx:61-71`의 `<div className="min-w-0 w-full">` 래퍼 + `className="rounded-lg max-w-full" style={{ width: '100%', maxWidth: '600px' }}` 적용으로 canvas가 부모 컬럼 폭에 맞춰 축소됨; 동일 패턴이 `GraphCanvas.tsx:85-95`에도 적용. `시작` 버튼 click이 18/18 케이스에서 타임아웃 없이 성공. (iter-1: 4) |
+
+- **평균**: (10 + 10 + 10 + 10 + 9 + 10 + 10) / 7 = **9.857**
+- **최저 항목**: #5 Scope Discipline = **9**
+
+---
+
+## 3. 판정
+
+- 평균 9.857 ≥ 8.0 ? **YES**
+- 모든 항목 ≥ 6.0 ? **YES** (최저 9)
+- **판정: PASS**
+
+---
+
+## 4. 정체(plateau) 감지
+
+- 이전 평균(iter-1): **6.14**
+- 이번 평균(iter-2): **9.857**
+- 상승폭: **+3.717**
+- 임계값 PLATEAU_EPS=0.3, 상승폭 +3.717 >> 0.3
+- plateau 여부: **NO** (대폭 개선됨)
+
+### iter-1 지적사항 해소 추적
+
+| iter-1 피드백 | 상태 | 증거 |
+|--------------|------|------|
+| Canvas 고정 width(600) → overflow로 pointer intercept | ✅ 해소 | `SortCanvas.tsx:68-69` `className="rounded-lg max-w-full" style={{ width: '100%', maxWidth: '600px' }}`; `GraphCanvas.tsx:92-93` 동일 패턴; 부모 `<div className="min-w-0 w-full">` 래퍼 + Panel 우측 컬럼 `<div className="flex items-start justify-center min-w-0">` (`SortPanel.tsx:128`, `GraphPanel.tsx:169`). Playwright 18/18 pass. |
+| useKeyboardNav 단위 테스트 부재 | ✅ 해소 | `src/hooks/__tests__/useKeyboardNav.spec.ts` (82 lines, 6 `it` 블록) 신규 작성. 케이스: active=true/ArrowRight, active=true/ArrowLeft, active=false/ArrowRight, active=false/ArrowLeft, Input focus, Textarea focus. `Tests 31 passed (31)`. |
+| `.claude/` 하위 7개 파일 범위 외 수정 | 부분 해소 | staged diff에는 제외됨(커밋 분리 ✓). 단 workdir에 여전히 수정된 채로 존재. restore 또는 별도 commit이 아직 실행되지 않음 → Scope Discipline -1. |
+
+---
+
+## 5. Generator Feedback
+
+PASS 판정이므로 별도 피드백 없음. 참고용 마무리 제안만:
+
+- (선택) `git restore .claude/commands/*.md .claude/skills/**/SKILL.md .claude/go-sdlc-gan.json` 로 workdir 정리, 또는 별도 이슈(`chore: update ship/kanban skill notes`)로 분리 커밋. 다음 iteration 평가에서 Scope Discipline 10/10 확보용.
+
+---
+
+## 6. 메타
+
+### build log tail
+
+```
+> alg-sdlc-gan@0.0.0 build
+> tsc -b && vite build
+
+vite v8.0.8 building client environment for production...
+✓ 28 modules transformed.
+dist/index.html                   0.45 kB │ gzip:  0.29 kB
+dist/assets/index-ITSrwbw2.css   11.51 kB │ gzip:  3.22 kB
+dist/assets/index-CbrWzmUV.js   205.14 kB │ gzip: 64.31 kB
+✓ built in 61ms
+---EXIT:0---
+```
+
+### test log tail (unit)
+
+```
+> alg-sdlc-gan@0.0.0 test
+> vitest run
+
+ RUN  v4.1.4 /Users/insang/Documents/lab/practices/alg-sdlc-gan
+
+ Test Files  9 passed (9)
+      Tests  31 passed (31)
+   Start at  12:26:56
+   Duration  798ms (transform 293ms, setup 0ms, import 737ms, tests 161ms, environment 4.26s)
+
+---EXIT:0---
+```
+
+### Playwright log tail (responsive-a11y)
+
+```
+Running 18 tests using 5 workers
+  ✓   4 [chromium] › Canvas에 role="img" 속성 존재 (515ms)
+  ✓   2 [chromium] › 뷰포트 768px에서 2-column 레이아웃 확인 (529ms)
+  ✓   5 [chromium] › 모든 StepControls 버튼에 aria-label 존재 (572ms)
+  ✓   3 [chromium] › 방향키로 이전/다음 스텝 이동 (595ms)
+  ✓   1 [chromium] › StepControls 버튼 터치 타깃 44px 이상 (610ms)
+  ✓   6 [chromium] › 그래프 BFS 2-column 레이아웃 확인 (254ms)
+  ✓   7-12 [firefox] × 6 (passed)
+  ✓  13-18 [webkit]  × 6 (passed)
+
+  18 passed (7.4s)
+---EXIT:0---
+```
+
+### Playwright full suite
+
+```
+... (중략)
+  48 passed (9.5s)
+---EXIT:0---
+```
+
+### lint
+
+```
+> alg-sdlc-gan@0.0.0 lint
+> eslint .
+---EXIT:0---
+```
+
+### changed files (staged, commit 대상)
+
+```
+ e2e/responsive-a11y.spec.ts                 |  85 ++++++++++++  (신규)
+ src/components/StepControls.tsx             |  10 +-
+ src/features/graph/GraphCanvas.tsx          |  19 +--
+ src/features/graph/GraphPanel.tsx           | 147 ++++++++++++---------
+ src/features/sort/SortCanvas.tsx            |  19 +--
+ src/features/sort/SortPanel.tsx             | 117 +++++++++-------
+ src/hooks/__tests__/useKeyboardNav.spec.ts  |  82 ++++++++++++  (신규)
+ src/hooks/useKeyboardNav.ts                 |  25 ++++         (신규)
+ 8 files changed, 366 insertions(+), 138 deletions(-)
+```
+
+### workdir unstaged (commit 대상 아님)
+
+```
+ .claude/commands/implement.md         |   1 -
+ .claude/commands/ship-all.md          |   1 -
+ .claude/commands/ship.md              |   1 -
+ .claude/go-sdlc-gan.json              |   4 +-
+ .claude/skills/auto-ship/SKILL.md     |  56 +++++-
+ .claude/skills/github-flow-impl/SKILL.md |  24 +++-
+ .claude/skills/github-kanban/SKILL.md  |  58 +++++--
+ 7 files changed, 120 insertions(+), 25 deletions(-)
+```

--- a/alg-sdlc-gan/docs/evaluations/issue-18/sprint-contract.md
+++ b/alg-sdlc-gan/docs/evaluations/issue-18/sprint-contract.md
@@ -1,0 +1,55 @@
+# Sprint Contract — Issue #18
+
+> 이 문서는 Generator와 Evaluator가 **동일하게 참조하는 계약서**다.
+> 한 번 잠그면 iteration 동안 변경되지 않는다.
+
+## Issue
+- 번호: #18
+- 제목: [L3][UI/UX] 전역 반응형 레이아웃 + 접근성 (키보드 탐색, aria)
+- 브랜치: feature/issue-15-16-graph-viz
+- 잠금 시각: 2026-04-19T00:00:00+09:00
+
+## Acceptance Criteria (원문)
+- [ ] Playwright 뷰포트 768px: 좌측 InputPanel + 우측 Canvas 2-column 레이아웃 확인
+- [ ] `←`/`→` 방향키로 이전/다음 스텝 이동 동작 확인
+- [ ] 모든 버튼 `aria-label`, Canvas `role="img"` 속성 존재 확인
+- [ ] 터치 타깃 44px 이상 확인
+
+## Testable Criteria (TC)
+
+| ID | 형식 | 본문 | 검증 방법 |
+|----|------|------|-----------|
+| TC-01 | given/when/then | Given 뷰포트 너비 768px이고 버블 정렬이 선택된 상태, when SortPanel을 렌더링하면, then `.grid.md:grid-cols-2` 요소가 visible이고 Canvas의 `boundingBox().x`가 InputPanel의 `boundingBox().x`보다 크다 | `npm run test:e2e -- --grep "뷰포트 768px"` |
+| TC-02 | given/when/then | Given 뷰포트 너비 768px이고 BFS가 선택된 상태, when GraphPanel을 렌더링하면, then `.grid.md:grid-cols-2` 요소가 visible이고 Canvas의 `boundingBox().x`가 EdgeInput의 `boundingBox().x`보다 크다 | `npm run test:e2e -- --grep "그래프 BFS 2-column"` |
+| TC-03 | given/when/then | Given 버블 정렬 시작 상태(active=true), when `ArrowRight` 키를 누르면, then `[aria-live="polite"]` 텍스트가 이전과 달라진다 (스텝 증가) (가정: Input/Textarea에 포커스가 없는 상태) | `npm run test:e2e -- --grep "방향키로 이전/다음"` |
+| TC-04 | given/when/then | Given TC-03에서 ArrowRight를 1회 누른 상태, when `ArrowLeft` 키를 누르면, then `[aria-live="polite"]` 텍스트가 ArrowRight 이전 값으로 복원된다 | `npm run test:e2e -- --grep "방향키로 이전/다음"` |
+| TC-05 | given/when/then | Given useKeyboardNav이 active=false로 호출된 상태, when `ArrowRight` 키를 누르면, then onNext 콜백이 호출되지 않는다 | `npm test -- useKeyboardNav` |
+| TC-06 | given/when/then | Given 버블 정렬 시작 상태, when StepControls가 렌더링되면, then `aria-label="이전 스텝"`, `aria-label="다음 스텝"`, `aria-label="재생"` 속성을 가진 버튼이 각각 DOM에 존재한다 | `npm run test:e2e -- --grep "StepControls 버튼에 aria-label"` |
+| TC-07 | given/when/then | Given 버블 정렬이 선택된 상태, when VisualizationCanvas(또는 canvas 엘리먼트)가 렌더링되면, then `role="img"` 속성이 canvas 엘리먼트에 존재한다 | `npm run test:e2e -- --grep "Canvas에 role"` |
+| TC-08 | given/when/then | Given 버블 정렬 시작 상태, when `aria-label="이전 스텝"` 버튼의 boundingBox를 측정하면, then height가 44 이상이다 | `npm run test:e2e -- --grep "터치 타깃 44px"` |
+| TC-09 | command→expected | `npm run build` | 종료 코드 0, stderr에 TypeScript 타입 에러 없음 |
+| TC-10 | command→expected | `npm run test:e2e -- e2e/responsive-a11y.spec.ts` | 종료 코드 0, 6개 테스트 모두 passed |
+
+## Non-goals
+
+- 정렬 알고리즘 로직(버블/선택/삽입 정렬 엔진) 수정 — #12, #13, #14 범위 (추론)
+- 그래프 BFS/DFS 엔진 로직 수정 — #15, #16 범위 (추론)
+- 마우스/터치 드래그 인터랙션 구현 — 별도 이슈로 분리 필요 (추론)
+- 다크모드 또는 테마 전환 기능 — 이슈 본문에 언급 없음 (추론)
+- `src/features/sort/engine.ts`, `src/features/graph/engine.ts` 수정 금지
+
+## Definition of Done
+
+- [ ] 모든 TC Pass
+- [ ] `npm run build` 종료 코드 0
+- [ ] `npm test` 종료 코드 0
+- [ ] Evaluator rubric 평균 ≥ 8.0 AND 각 항목 ≥ 6.0
+- [ ] Non-goals 침범 없음
+- [ ] 기존 테스트 파손 없음
+
+## 해석 기록
+
+- **AC1 (2-column 레이아웃)**: "좌측 InputPanel + 우측 Canvas"의 기준을 `boundingBox().x` 비교로 정의했다. CSS 클래스 존재 확인(TC-01/02)만으로는 실제 배치를 보장할 수 없으므로 좌표 비교를 병행한다. 정렬과 그래프 패널 각각에 대해 TC를 분리했다(TC-01, TC-02).
+- **AC2 (방향키 이동)**: `[aria-live="polite"]` 텍스트 변화를 관찰 가능한 결과로 채택했다. `active=false` 시 무시 동작은 useKeyboardNav 단위 테스트(TC-05)로 검증한다. "Input/Textarea에 포커스 없음" 조건은 훅 내부 가드(`instanceof HTMLInputElement`) 기반이므로 전제로 명시했다.
+- **AC3 (aria 속성)**: 버튼 aria-label(TC-06)과 Canvas role(TC-07)을 별도 TC로 분리했다. "모든 버튼"의 범위를 StepControls 내 이전/다음/재생 3개 버튼으로 한정했다(이슈 본문의 구현 파일 기준).
+- **AC4 (터치 타깃 44px)**: WCAG 2.5.5 기준인 44×44px 중 height만 e2e로 측정한다(가정: width도 동일 클래스 적용). `min-h-[44px]`(Tailwind) 적용 버튼을 대표 샘플로 "이전 스텝" 버튼을 선택했다.

--- a/alg-sdlc-gan/e2e/responsive-a11y.spec.ts
+++ b/alg-sdlc-gan/e2e/responsive-a11y.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('@slice:a11y 반응형 레이아웃 + 접근성', () => {
+  test('뷰포트 768px에서 2-column 레이아웃 확인', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 900 })
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+
+    const grid = page.locator('.grid.md\\:grid-cols-2').first()
+    await expect(grid).toBeVisible()
+
+    // 좌측 입력 패널과 우측 캔버스가 나란히 배치됨을 확인
+    const inputPanel = page.getByLabel('정렬할 배열 입력')
+    const canvas = page.locator('canvas[aria-label="정렬 시각화 캔버스"]')
+    await expect(inputPanel).toBeVisible()
+    await expect(canvas).toBeVisible()
+
+    const inputBox = await inputPanel.boundingBox()
+    const canvasBox = await canvas.boundingBox()
+    // 768px 이상에서는 canvas가 입력 패널보다 오른쪽에 위치
+    expect(canvasBox!.x).toBeGreaterThan(inputBox!.x)
+  })
+
+  test('방향키로 이전/다음 스텝 이동', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+    await page.getByRole('button', { name: '시작' }).click()
+
+    const indicator = page.locator('[aria-live="polite"]')
+    const step1 = await indicator.textContent()
+
+    await page.keyboard.press('ArrowRight')
+    const step2 = await indicator.textContent()
+    expect(step2).not.toBe(step1)
+
+    await page.keyboard.press('ArrowLeft')
+    const step3 = await indicator.textContent()
+    expect(step3).toBe(step1)
+  })
+
+  test('모든 StepControls 버튼에 aria-label 존재', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+    await page.getByRole('button', { name: '시작' }).click()
+
+    await expect(page.getByLabel('이전 스텝')).toBeVisible()
+    await expect(page.getByLabel('다음 스텝')).toBeVisible()
+    await expect(page.getByLabel('재생')).toBeVisible()
+  })
+
+  test('Canvas에 role="img" 속성 존재', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+
+    await expect(page.locator('canvas[role="img"]')).toBeVisible()
+  })
+
+  test('StepControls 버튼 터치 타깃 44px 이상', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('버블 정렬 선택').click()
+    await page.getByRole('button', { name: '시작' }).click()
+
+    const prevBtn = page.getByLabel('이전 스텝')
+    const box = await prevBtn.boundingBox()
+    expect(box!.height).toBeGreaterThanOrEqual(44)
+  })
+
+  test('그래프 BFS 2-column 레이아웃 확인', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 900 })
+    await page.goto('/')
+    await page.getByLabel('BFS 선택').click()
+
+    const grid = page.locator('.grid.md\\:grid-cols-2').first()
+    await expect(grid).toBeVisible()
+
+    const edgeInput = page.getByLabel('그래프 엣지 입력')
+    const canvas = page.locator('canvas[aria-label="그래프 시각화 캔버스"]')
+    await expect(edgeInput).toBeVisible()
+    await expect(canvas).toBeVisible()
+
+    const inputBox = await edgeInput.boundingBox()
+    const canvasBox = await canvas.boundingBox()
+    expect(canvasBox!.x).toBeGreaterThan(inputBox!.x)
+  })
+})

--- a/alg-sdlc-gan/src/components/StepControls.tsx
+++ b/alg-sdlc-gan/src/components/StepControls.tsx
@@ -29,7 +29,7 @@ export function StepControls({
           onClick={onPrev}
           disabled={isIdle}
           aria-label="이전 스텝"
-          className="rounded-md bg-slate-700 px-3 py-1.5 text-sm disabled:opacity-40"
+          className="rounded-md bg-slate-700 px-3 py-2.5 min-h-[44px] text-sm disabled:opacity-40"
         >
           ◀
         </button>
@@ -39,7 +39,7 @@ export function StepControls({
             onClick={onPause}
             disabled={isIdle}
             aria-label="일시정지"
-            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm disabled:opacity-40"
+            className="rounded-md bg-indigo-600 px-3 py-2.5 min-h-[44px] text-sm disabled:opacity-40"
           >
             ⏸
           </button>
@@ -48,7 +48,7 @@ export function StepControls({
             onClick={onPlay}
             disabled={isIdle}
             aria-label="재생"
-            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm disabled:opacity-40"
+            className="rounded-md bg-indigo-600 px-3 py-2.5 min-h-[44px] text-sm disabled:opacity-40"
           >
             ▶
           </button>
@@ -58,7 +58,7 @@ export function StepControls({
           onClick={onNext}
           disabled={isIdle}
           aria-label="다음 스텝"
-          className="rounded-md bg-slate-700 px-3 py-1.5 text-sm disabled:opacity-40"
+          className="rounded-md bg-slate-700 px-3 py-2.5 min-h-[44px] text-sm disabled:opacity-40"
         >
           ▶▶
         </button>
@@ -73,7 +73,7 @@ export function StepControls({
           value={speed}
           disabled={isIdle || isPlaying}
           onChange={(e) => onSpeedChange(Number(e.target.value))}
-          aria-label="재생 속도"
+          aria-label="속도 조절"
           className="accent-indigo-500 disabled:opacity-40"
         />
       </label>

--- a/alg-sdlc-gan/src/features/graph/GraphCanvas.tsx
+++ b/alg-sdlc-gan/src/features/graph/GraphCanvas.tsx
@@ -82,13 +82,16 @@ export function GraphCanvas({ nodes, edges, step, width = 600, height = 360 }: P
   }, [nodes, edges, step, width, height])
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={width}
-      height={height}
-      role="img"
-      aria-label="그래프 시각화 캔버스"
-      className="rounded-lg"
-    />
+    <div className="min-w-0 w-full">
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        role="img"
+        aria-label="그래프 시각화 캔버스"
+        className="rounded-lg max-w-full"
+        style={{ width: '100%', maxWidth: `${width}px` }}
+      />
+    </div>
   )
 }

--- a/alg-sdlc-gan/src/features/graph/GraphPanel.tsx
+++ b/alg-sdlc-gan/src/features/graph/GraphPanel.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { GraphCanvas } from './GraphCanvas'
 import { StepControls } from '../../components/StepControls'
 import { StepIndicator } from '../../components/StepIndicator'
 import { computeGraphSteps } from './engine'
 import { normalizeCoordinates } from './utils'
+import { useKeyboardNav } from '../../hooks/useKeyboardNav'
 import type { GraphNode, GraphEdge } from '../../types'
 import type { GraphAlgorithm } from './engine'
 
@@ -86,79 +87,93 @@ export function GraphPanel({ algorithm }: Props) {
     }
   }, [playState, speed, steps.length])
 
+  const handlePrev = useCallback(() => setCurrentStep((p) => Math.max(0, p - 1)), [])
+  const handleNext = useCallback(() => {
+    setCurrentStep((p) => {
+      const next = Math.min(p + 1, steps.length - 1)
+      if (next === steps.length - 1) setPlayState('done')
+      return next
+    })
+  }, [steps.length])
+
+  useKeyboardNav(handlePrev, handleNext, playState !== 'idle')
+
   const isDone = playState === 'done'
   const currentStepData = graphData ? (steps[currentStep] ?? null) : null
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <input
-          type="text"
-          value={edgeInput}
-          onChange={(e) => setEdgeInput(e.target.value)}
-          disabled={playState === 'playing'}
-          placeholder="예: A-B,B-C,C-A"
-          className="flex-1 rounded-md bg-slate-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
-          aria-label="그래프 엣지 입력"
-        />
-        <input
-          type="text"
-          value={startNode}
-          onChange={(e) => setStartNode(e.target.value)}
-          disabled={playState === 'playing'}
-          placeholder="시작 노드"
-          className="w-24 rounded-md bg-slate-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
-          aria-label="시작 노드 입력"
-        />
-        <button
-          onClick={handleStart}
-          className="rounded-md bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
-        >
-          시작
-        </button>
-      </div>
+      {/* 2-column layout at md+ */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* 좌측: 입력 + 컨트롤 */}
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="text"
+              value={edgeInput}
+              onChange={(e) => setEdgeInput(e.target.value)}
+              disabled={playState === 'playing'}
+              placeholder="예: A-B,B-C,C-A"
+              className="flex-1 rounded-md bg-slate-700 px-3 py-2.5 text-sm text-white disabled:opacity-50"
+              aria-label="그래프 엣지 입력"
+            />
+            <input
+              type="text"
+              value={startNode}
+              onChange={(e) => setStartNode(e.target.value)}
+              disabled={playState === 'playing'}
+              placeholder="시작 노드"
+              className="w-24 rounded-md bg-slate-700 px-3 py-2.5 text-sm text-white disabled:opacity-50"
+              aria-label="시작 노드 입력"
+            />
+            <button
+              onClick={handleStart}
+              aria-label="탐색 시작"
+              className="rounded-md bg-indigo-600 px-4 py-2.5 min-h-[44px] text-sm font-medium text-white hover:bg-indigo-500"
+            >
+              시작
+            </button>
+          </div>
 
-      {error && <p className="text-sm text-red-400">{error}</p>}
+          {error && <p className="text-sm text-red-400">{error}</p>}
 
-      <GraphCanvas
-        nodes={graphData?.nodes ?? []}
-        edges={graphData?.edges ?? []}
-        step={currentStepData}
-      />
+          <StepControls
+            playState={playState}
+            onPrev={handlePrev}
+            onNext={handleNext}
+            onPlay={() => setPlayState('playing')}
+            onPause={() => setPlayState('paused')}
+            speed={speed}
+            onSpeedChange={setSpeed}
+          />
+          <StepIndicator currentStep={currentStep} total={steps.length} />
 
-      <div className="flex items-center justify-between">
-        <StepControls
-          playState={playState}
-          onPrev={() => setCurrentStep((p) => Math.max(0, p - 1))}
-          onNext={() => {
-            setCurrentStep((p) => {
-              const next = Math.min(p + 1, steps.length - 1)
-              if (next === steps.length - 1) setPlayState('done')
-              return next
-            })
-          }}
-          onPlay={() => setPlayState('playing')}
-          onPause={() => setPlayState('paused')}
-          speed={speed}
-          onSpeedChange={setSpeed}
-        />
-        <StepIndicator currentStep={currentStep} total={steps.length} />
-      </div>
-
-      {isDone && (
-        <div className="flex items-center justify-between rounded-md bg-slate-700 px-4 py-2">
-          <span className="text-sm text-green-400 font-medium">탐색 완료!</span>
-          <button
-            onClick={() => {
-              setCurrentStep(0)
-              setPlayState('paused')
-            }}
-            className="rounded-md bg-slate-600 px-3 py-1 text-sm text-white hover:bg-slate-500"
-          >
-            처음으로
-          </button>
+          {isDone && (
+            <div className="flex items-center justify-between rounded-md bg-slate-700 px-4 py-2">
+              <span className="text-sm text-green-400 font-medium">탐색 완료!</span>
+              <button
+                onClick={() => {
+                  setCurrentStep(0)
+                  setPlayState('paused')
+                }}
+                aria-label="처음으로 돌아가기"
+                className="rounded-md bg-slate-600 px-3 py-2.5 min-h-[44px] text-sm text-white hover:bg-slate-500"
+              >
+                처음으로
+              </button>
+            </div>
+          )}
         </div>
-      )}
+
+        {/* 우측: Canvas */}
+        <div className="flex items-start justify-center min-w-0">
+          <GraphCanvas
+            nodes={graphData?.nodes ?? []}
+            edges={graphData?.edges ?? []}
+            step={currentStepData}
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/alg-sdlc-gan/src/features/sort/SortCanvas.tsx
+++ b/alg-sdlc-gan/src/features/sort/SortCanvas.tsx
@@ -58,13 +58,16 @@ export function SortCanvas({ step, width = 600, height = 360 }: Props) {
   }, [step, width, height])
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={width}
-      height={height}
-      role="img"
-      aria-label="정렬 시각화 캔버스"
-      className="rounded-lg"
-    />
+    <div className="min-w-0 w-full">
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        role="img"
+        aria-label="정렬 시각화 캔버스"
+        className="rounded-lg max-w-full"
+        style={{ width: '100%', maxWidth: `${width}px` }}
+      />
+    </div>
   )
 }

--- a/alg-sdlc-gan/src/features/sort/SortPanel.tsx
+++ b/alg-sdlc-gan/src/features/sort/SortPanel.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { SortCanvas } from './SortCanvas'
 import { StepControls } from '../../components/StepControls'
 import { StepIndicator } from '../../components/StepIndicator'
 import { computeSortSteps } from './engine'
 import { validateSortInput } from './utils'
+import { useKeyboardNav } from '../../hooks/useKeyboardNav'
 import type { SortAlgorithm } from './engine'
 
 interface Props {
@@ -54,66 +55,80 @@ export function SortPanel({ algorithm }: Props) {
     }
   }, [playState, speed, steps.length])
 
+  const handlePrev = useCallback(() => setCurrentStep((p) => Math.max(0, p - 1)), [])
+  const handleNext = useCallback(() => {
+    setCurrentStep((p) => {
+      const next = Math.min(p + 1, steps.length - 1)
+      if (next === steps.length - 1) setPlayState('done')
+      return next
+    })
+  }, [steps.length])
+
+  useKeyboardNav(handlePrev, handleNext, playState !== 'idle')
+
   const isDone = playState === 'done'
   const currentStepData = steps[currentStep] ?? null
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          disabled={playState === 'playing'}
-          placeholder="예: 5,3,8,1"
-          className="flex-1 rounded-md bg-slate-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
-          aria-label="정렬할 배열 입력"
-        />
-        <button
-          onClick={handleStart}
-          className="rounded-md bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
-        >
-          시작
-        </button>
-      </div>
+      {/* 2-column layout at md+ */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* 좌측: 입력 + 컨트롤 */}
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={playState === 'playing'}
+              placeholder="예: 5,3,8,1"
+              className="flex-1 rounded-md bg-slate-700 px-3 py-2.5 text-sm text-white disabled:opacity-50"
+              aria-label="정렬할 배열 입력"
+            />
+            <button
+              onClick={handleStart}
+              aria-label="정렬 시작"
+              className="rounded-md bg-indigo-600 px-4 py-2.5 min-h-[44px] text-sm font-medium text-white hover:bg-indigo-500"
+            >
+              시작
+            </button>
+          </div>
 
-      {error && <p className="text-sm text-red-400">{error}</p>}
+          {error && <p className="text-sm text-red-400">{error}</p>}
 
-      <SortCanvas step={currentStepData} />
+          <StepControls
+            playState={playState}
+            onPrev={handlePrev}
+            onNext={handleNext}
+            onPlay={() => setPlayState('playing')}
+            onPause={() => setPlayState('paused')}
+            speed={speed}
+            onSpeedChange={setSpeed}
+          />
+          <StepIndicator currentStep={currentStep} total={steps.length} />
 
-      <div className="flex items-center justify-between">
-        <StepControls
-          playState={playState}
-          onPrev={() => setCurrentStep((p) => Math.max(0, p - 1))}
-          onNext={() => {
-            setCurrentStep((p) => {
-              const next = Math.min(p + 1, steps.length - 1)
-              if (next === steps.length - 1) setPlayState('done')
-              return next
-            })
-          }}
-          onPlay={() => setPlayState('playing')}
-          onPause={() => setPlayState('paused')}
-          speed={speed}
-          onSpeedChange={setSpeed}
-        />
-        <StepIndicator currentStep={currentStep} total={steps.length} />
-      </div>
-
-      {isDone && (
-        <div className="flex items-center justify-between rounded-md bg-slate-700 px-4 py-2">
-          <span className="text-sm text-green-400 font-medium">정렬 완료!</span>
-          <button
-            onClick={() => {
-              setCurrentStep(0)
-              setPlayState('paused')
-            }}
-            className="rounded-md bg-slate-600 px-3 py-1 text-sm text-white hover:bg-slate-500"
-          >
-            처음으로
-          </button>
+          {isDone && (
+            <div className="flex items-center justify-between rounded-md bg-slate-700 px-4 py-2">
+              <span className="text-sm text-green-400 font-medium">정렬 완료!</span>
+              <button
+                onClick={() => {
+                  setCurrentStep(0)
+                  setPlayState('paused')
+                }}
+                aria-label="처음으로 돌아가기"
+                className="rounded-md bg-slate-600 px-3 py-2.5 min-h-[44px] text-sm text-white hover:bg-slate-500"
+              >
+                처음으로
+              </button>
+            </div>
+          )}
         </div>
-      )}
+
+        {/* 우측: Canvas */}
+        <div className="flex items-start justify-center min-w-0">
+          <SortCanvas step={currentStepData} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/alg-sdlc-gan/src/hooks/__tests__/useKeyboardNav.spec.ts
+++ b/alg-sdlc-gan/src/hooks/__tests__/useKeyboardNav.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useKeyboardNav } from '../useKeyboardNav'
+
+describe('useKeyboardNav', () => {
+  let onPrev: () => void
+  let onNext: () => void
+
+  beforeEach(() => {
+    onPrev = vi.fn() as () => void
+    onNext = vi.fn() as () => void
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('active=true일 때 ArrowRight 키를 누르면 onNext가 호출된다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, true))
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+
+    expect(onNext).toHaveBeenCalledOnce()
+    expect(onPrev).not.toHaveBeenCalled()
+  })
+
+  it('active=true일 때 ArrowLeft 키를 누르면 onPrev가 호출된다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, true))
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+
+    expect(onPrev).toHaveBeenCalledOnce()
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('active=false일 때 ArrowRight를 눌러도 onNext가 호출되지 않는다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, false))
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+
+    expect(onNext).not.toHaveBeenCalled()
+    expect(onPrev).not.toHaveBeenCalled()
+  })
+
+  it('active=false일 때 ArrowLeft를 눌러도 onPrev가 호출되지 않는다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, false))
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+
+    expect(onPrev).not.toHaveBeenCalled()
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it('HTMLInputElement에 포커스된 상태에서 ArrowRight를 누르면 onNext가 호출되지 않는다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, true))
+
+    // input 요소를 타겟으로 이벤트 발생
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+
+    expect(onNext).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+  })
+
+  it('HTMLTextAreaElement에 포커스된 상태에서 ArrowLeft를 누르면 onPrev가 호출되지 않는다', () => {
+    renderHook(() => useKeyboardNav(onPrev, onNext, true))
+
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+
+    expect(onPrev).not.toHaveBeenCalled()
+
+    document.body.removeChild(textarea)
+  })
+})

--- a/alg-sdlc-gan/src/hooks/useKeyboardNav.ts
+++ b/alg-sdlc-gan/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+export function useKeyboardNav(
+  onPrev: () => void,
+  onNext: () => void,
+  active: boolean
+) {
+  useEffect(() => {
+    if (!active) return
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        onPrev()
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        onNext()
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onPrev, onNext, active])
+}


### PR DESCRIPTION
## Summary
- `useKeyboardNav` 훅 신규: ArrowLeft/ArrowRight 방향키 탐색
- `SortPanel` / `GraphPanel`: md(768px) 이상에서 2-column 레이아웃
- `SortCanvas` / `GraphCanvas`: `max-w-full` + `min-w-0` canvas overflow 수정
- `StepControls`: 모든 버튼 `min-h-[44px]` 터치 타깃 보장
- `e2e/responsive-a11y.spec.ts`: 6개 시나리오 (3브라우저 × 6 = 18 passed)

## Changes
- `src/hooks/useKeyboardNav.ts` — 신규
- `src/hooks/__tests__/useKeyboardNav.spec.ts` — 신규 (6 unit tests)
- `src/features/sort/SortPanel.tsx` — 2-column 레이아웃, 키보드 탐색
- `src/features/graph/GraphPanel.tsx` — 동일
- `src/features/sort/SortCanvas.tsx` — max-w-full 반응형
- `src/features/graph/GraphCanvas.tsx` — 동일
- `src/components/StepControls.tsx` — min-h-[44px] 터치 타깃
- GAN 루프: iter-2 평균 9.857 PASS

Closes #18